### PR TITLE
Refresh OPFS OPFS test runner styling

### DIFF
--- a/tests/opfs-API-tests/css/opfs-tests.css
+++ b/tests/opfs-API-tests/css/opfs-tests.css
@@ -1,0 +1,144 @@
+:root {
+  color-scheme: light dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: linear-gradient(180deg, #f9fbfd 0%, #edf2f8 100%);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #1f2933;
+}
+
+main {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2vw, 1.75rem);
+  padding: clamp(1.5rem, 2vw + 1rem, 2.75rem);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 44px -28px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(12px);
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: clamp(1.65rem, 2.6vw, 2.35rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  padding: 0.35rem 0.75rem;
+  border-radius: 12px;
+  background: #eef2ff;
+  color: #2f3e9e;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.6;
+  color: #52606d;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.95rem;
+  color: #52606d;
+}
+
+.controls input[type="checkbox"] {
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 0.35rem;
+  border: 1px solid #cbd2d9;
+  accent-color: #4338ca;
+}
+
+#test-output {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: min(70vh, 640px);
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  background: rgba(248, 250, 252, 0.95);
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  overflow: auto;
+  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.08);
+}
+
+#test-output.reverse {
+  flex-direction: column-reverse;
+}
+
+.log-entry {
+  margin: 0;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: inherit;
+  white-space: break-spaces;
+}
+
+.log-entry:nth-child(even) {
+  background: rgba(236, 242, 255, 0.6);
+}
+
+.log-entry.warning {
+  border-color: rgba(245, 158, 11, 0.4);
+  background: rgba(255, 247, 231, 0.95);
+  color: #b45309;
+}
+
+.log-entry.error {
+  border-color: rgba(220, 38, 38, 0.35);
+  background: rgba(254, 226, 226, 0.95);
+  color: #b91c1c;
+}
+
+.tests-pass {
+  background: #2dd4bf !important;
+  color: #0f172a !important;
+}
+
+.tests-fail {
+  background: #f87171 !important;
+  color: #111827 !important;
+}
+
+@media (max-width: 680px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  main {
+    padding: 1.5rem;
+    gap: 1.25rem;
+  }
+
+  #test-output {
+    max-height: 60vh;
+  }
+}

--- a/tests/opfs-API-tests/index.html
+++ b/tests/opfs-API-tests/index.html
@@ -1,1 +1,28 @@
-OPFS API tests
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />
+    <link rel="stylesheet" href="../../src/common/emscripten.css" />
+    <link rel="stylesheet" href="./css/opfs-tests.css" />
+    <title>sqlite3 OPFS API tests</title>
+  </head>
+  <body>
+    <main>
+      <header class="page-header">
+        <h1 id="color-target">sqlite3 OPFS API tests</h1>
+        <p class="subtitle">
+          Run the full Origin Private File System regression suite for the sqlite3 WASM build and
+          monitor log output in real time.
+        </p>
+      </header>
+      <label class="controls" for="cb-log-reverse">
+        <input type="checkbox" id="cb-log-reverse" />
+        <span>Show newest log entries first</span>
+      </label>
+      <div id="test-output" role="log" aria-live="polite"></div>
+    </main>
+    <script type="module" src="./js/main.js"></script>
+  </body>
+</html>

--- a/tests/opfs-API-tests/js/main.js
+++ b/tests/opfs-API-tests/js/main.js
@@ -1,0 +1,40 @@
+import sqlite3InitModule from "../../../src/jswasm/sqlite3.mjs";
+import { initUi } from "./ui.js";
+import { createTestHarness } from "./test-harness.js";
+import { registerOpfsTests, setSqliteReferences } from "./opfs-tests.js";
+
+globalThis.sqlite3InitModule = sqlite3InitModule;
+
+const ui = initUi();
+const harness = createTestHarness(ui);
+registerOpfsTests({ T: harness.T, error: ui.error });
+
+const main = async () => {
+  ui.log("Loading and initializing sqlite3 WASM module...");
+  sqlite3InitModule.__isUnderTest = true;
+  const sqlite3 = await sqlite3InitModule({
+    print: ui.log,
+    printErr: ui.error,
+  });
+  harness.T.assert(!!sqlite3.util);
+  ui.log("Done initializing WASM/JS bits. Running tests...");
+  sqlite3.config.warn(
+    "Installing sqlite3 bits as global S for local dev/test purposes.",
+  );
+  globalThis.S = sqlite3;
+  setSqliteReferences(sqlite3);
+  const { capi, wasm } = sqlite3;
+  ui.log("sqlite3 version:", capi.sqlite3_libversion(), capi.sqlite3_sourceid());
+  if (wasm.bigIntEnabled) {
+    ui.log("BigInt/int64 support is enabled.");
+  } else {
+    ui.log("BigInt/int64 support is disabled.");
+  }
+  ui.log("registered vfs list =", capi.sqlite3_js_vfs_list().join(", "));
+  await harness.runTests(sqlite3);
+};
+
+main().catch((err) => {
+  ui.error("Fatal error while running tests:", err);
+  ui.reportFinalTestStatus(false);
+});

--- a/tests/opfs-API-tests/js/opfs-tests.js
+++ b/tests/opfs-API-tests/js/opfs-tests.js
@@ -1,0 +1,351 @@
+const sahPoolConfig = {
+  name: "opfs-sahpool-tester1",
+  clearOnInit: true,
+  initialCapacity: 6,
+};
+
+let capi;
+let wasm;
+
+const hasOpfs = () =>
+  !!(
+    globalThis.FileSystemHandle &&
+    globalThis.FileSystemDirectoryHandle &&
+    globalThis.FileSystemFileHandle &&
+    globalThis.FileSystemFileHandle.prototype.createSyncAccessHandle &&
+    navigator?.storage?.getDirectory
+  );
+
+export function setSqliteReferences(sqlite3) {
+  capi = sqlite3.capi;
+  wasm = sqlite3.wasm;
+}
+
+export function registerOpfsTests({ T, error }) {
+  T.g(
+    "OPFS: Origin-Private File System",
+    (sqlite3) =>
+      sqlite3.capi.sqlite3_vfs_find("opfs") || 'requires "opfs" VFS',
+  )
+    .t({
+      name: "OPFS db sanity checks",
+      async test(sqlite3) {
+        T.assert(capi.sqlite3_vfs_find("opfs"));
+        const opfs = sqlite3.opfs;
+        const filename = (this.opfsDbFile = "/dir/sqlite3-opfs-tests.db");
+        const fileUri = `file://${filename}?delete-before-open=1`;
+        const initSql = [
+          "create table p(a);",
+          "insert into p(a) values(1),(2),(3)",
+        ];
+        let db = new sqlite3.oo1.OpfsDb(fileUri);
+        try {
+          db.exec(initSql);
+          T.assert(3 === db.selectValue("select count(*) from p"));
+          db.close();
+          db = new sqlite3.oo1.OpfsDb(filename);
+          db.exec("insert into p(a) values(4),(5),(6)");
+          T.assert(6 === db.selectValue("select count(*) from p"));
+          this.opfsDbExport = capi.sqlite3_js_db_export(db);
+          T.assert(this.opfsDbExport instanceof Uint8Array).assert(
+            this.opfsDbExport.byteLength > 0 &&
+              this.opfsDbExport.byteLength % 512 === 0,
+          );
+        } finally {
+          db.close();
+        }
+        T.assert(await opfs.entryExists(filename));
+        try {
+          db = new sqlite3.oo1.OpfsDb(fileUri);
+          db.exec(initSql);
+          T.assert(3 === db.selectValue("select count(*) from p"));
+        } finally {
+          if (db) db.close();
+        }
+      },
+    })
+    .t({
+      name: "OPFS import",
+      async test(sqlite3) {
+        let db;
+        const filename = this.opfsDbFile;
+        try {
+          const exp = this.opfsDbExport;
+          delete this.opfsDbExport;
+          this.opfsImportSize = await sqlite3.oo1.OpfsDb.importDb(
+            filename,
+            exp,
+          );
+          db = new sqlite3.oo1.OpfsDb(this.opfsDbFile);
+          T.assert(6 === db.selectValue("select count(*) from p")).assert(
+            this.opfsImportSize === exp.byteLength,
+          );
+          db.close();
+          const unlink = (this.opfsUnlink = (fn = filename) =>
+            sqlite3.util.sqlite3__wasm_vfs_unlink("opfs", fn));
+          this.opfsUnlink(filename);
+          T.assert(!(await sqlite3.opfs.entryExists(filename)));
+          let cursor = 0;
+          const blockSize = 512;
+          const reader = async () => {
+            if (cursor >= exp.byteLength) {
+              return undefined;
+            }
+            const next = exp.subarray(
+              cursor,
+              Math.min(cursor + blockSize, exp.byteLength),
+            );
+            cursor += blockSize;
+            return next;
+          };
+          this.opfsImportSize = await sqlite3.oo1.OpfsDb.importDb(
+            filename,
+            reader,
+          );
+          db = new sqlite3.oo1.OpfsDb(this.opfsDbFile);
+          T.assert(6 === db.selectValue("select count(*) from p")).assert(
+            this.opfsImportSize === exp.byteLength,
+          );
+        } finally {
+          if (db) db.close();
+        }
+      },
+    })
+    .t({
+      name: "(Internal-use) OPFS utility APIs",
+      async test(sqlite3) {
+        const filename = this.opfsDbFile;
+        const unlink = this.opfsUnlink;
+        T.assert(filename && unlink);
+        delete this.opfsDbFile;
+        delete this.opfsUnlink;
+        const opfs = sqlite3.opfs;
+        const fSize = this.opfsImportSize;
+        delete this.opfsImportSize;
+        let sh;
+        try {
+          T.assert(await opfs.entryExists(filename));
+          const [dirHandle, filenamePart] = await opfs.getDirForFilename(
+            filename,
+            false,
+          );
+          const fh = await dirHandle.getFileHandle(filenamePart);
+          sh = await fh.createSyncAccessHandle();
+          T.assert(fSize === (await sh.getSize()));
+          await sh.close();
+          sh = undefined;
+          unlink();
+          T.assert(!(await opfs.entryExists(filename)));
+        } finally {
+          if (sh) await sh.close();
+          unlink();
+        }
+
+        const testDir = `/sqlite3-opfs-${opfs.randomFilename(12)}`;
+        const aDir = `${testDir}/test/dir`;
+        T.assert(await opfs.mkdir(aDir), "mkdir failed")
+          .assert(
+            await opfs.mkdir(aDir),
+            "mkdir must pass if the dir exists",
+          )
+          .assert(
+            !(await opfs.unlink(`${testDir}/test`)),
+            "delete 1 should have failed (dir not empty)",
+          )
+          .assert(
+            await opfs.unlink(`${testDir}/test/dir`),
+            "delete 2 failed",
+          )
+          .assert(
+            !(await opfs.unlink(`${testDir}/test/dir`)),
+            "delete 2b should have failed (dir already deleted)",
+          )
+          .assert(
+            await opfs.unlink(testDir, true),
+            "delete 3 failed",
+          )
+          .assert(
+            !(await opfs.entryExists(testDir)),
+            `entryExists(${testDir}) should have failed`,
+          );
+      },
+    });
+
+  T.g(
+    "OPFS SyncAccessHandle Pool VFS",
+    (sqlite3) => hasOpfs() || "requires OPFS APIs",
+  ).t({
+    name: "SAH sanity checks",
+    async test(sqlite3) {
+      T.assert(!sqlite3.capi.sqlite3_vfs_find(sahPoolConfig.name)).assert(
+        sqlite3.capi.sqlite3_js_vfs_list().indexOf(sahPoolConfig.name) < 0,
+      );
+      const inst = sqlite3.installOpfsSAHPoolVfs;
+      const catcher = (e) => {
+        error(
+          "Cannot load SAH pool VFS.",
+          "This might not be a problem,",
+          "depending on the environment.",
+        );
+        return false;
+      };
+      let u1;
+      let u2;
+      const P1 = inst(sahPoolConfig)
+        .then((u) => (u1 = u))
+        .catch(catcher);
+      const P2 = inst(sahPoolConfig)
+        .then((u) => (u2 = u))
+        .catch(catcher);
+      await Promise.all([P1, P2]);
+      if (!(await P1)) return;
+      T.assert(u1 === u2)
+        .assert(sahPoolConfig.name === u1.vfsName)
+        .assert(sqlite3.capi.sqlite3_vfs_find(sahPoolConfig.name))
+        .assert(u1.getCapacity() >= sahPoolConfig.initialCapacity)
+        .assert(u1.getCapacity() + 2 === (await u2.addCapacity(2)))
+        .assert(2 === (await u2.reduceCapacity(2)))
+        .assert(
+          sqlite3.capi
+            .sqlite3_js_vfs_list()
+            .indexOf(sahPoolConfig.name) >= 0,
+        );
+
+      T.assert(0 === u1.getFileCount());
+      const dbName = "/foo.db";
+      let db = new u1.OpfsSAHPoolDb(dbName);
+      T.assert(db instanceof sqlite3.oo1.DB).assert(
+        1 === u1.getFileCount(),
+      );
+      db.exec([
+        "pragma locking_mode=exclusive;",
+        "pragma journal_mode=wal;",
+        "create table t(a);",
+        "insert into t(a) values(1),(2),(3)",
+      ]);
+      T.assert(2 === u1.getFileCount())
+        .assert(3 === db.selectValue("select count(*) from t"))
+        .assert(
+          db.selectValue("pragma journal_mode") === "wal" ||
+            wasm.compileOptionUsed("OMIT_WAL"),
+        );
+      db.close();
+      T.assert(1 === u1.getFileCount());
+      db = new u2.OpfsSAHPoolDb(dbName);
+      T.assert(1 === u1.getFileCount())
+        .mustThrowMatching(
+          () => u1.pauseVfs(),
+          (err) =>
+            capi.SQLITE_MISUSE === err.resultCode &&
+            /^SQLITE_MISUSE: Cannot pause VFS /.test(err.message),
+          "Cannot pause VFS with opened db.",
+        );
+      db.close();
+      T.assert(u2 === u2.pauseVfs())
+        .assert(u2.isPaused())
+        .assert(0 === capi.sqlite3_vfs_find(u2.vfsName))
+        .mustThrowMatching(
+          () => new u2.OpfsSAHPoolDb(dbName),
+          /.+no such vfs: .+/,
+          "VFS is not available",
+        )
+        .assert(u2 === (await u2.unpauseVfs()))
+        .assert(
+          u2 === (await u1.unpauseVfs()),
+          "unpause is a no-op if the VFS is not paused",
+        )
+        .assert(0 !== capi.sqlite3_vfs_find(u2.vfsName));
+      const fileNames = u1.getFileNames();
+      T.assert(1 === fileNames.length)
+        .assert(dbName === fileNames[0])
+        .assert(1 === u1.getFileCount());
+
+      const dbytes = u1.exportFile(dbName);
+      T.assert(dbytes.length >= 4096);
+      const dbName2 = "/exported.db";
+      let nWrote = u1.importDb(dbName2, dbytes);
+      T.assert(2 === u1.getFileCount()).assert(
+        dbytes.byteLength === nWrote,
+      );
+      let db2 = new u1.OpfsSAHPoolDb(dbName2);
+      T.assert(db2 instanceof sqlite3.oo1.DB)
+        .assert(
+          "wal" !== db2.selectValue("pragma journal_mode"),
+        )
+        .assert(3 === db2.selectValue("select count(*) from t"));
+      db2.close();
+      T.assert(true === u1.unlink(dbName2))
+        .assert(false === u1.unlink(dbName2))
+        .assert(1 === u1.getFileCount())
+        .assert(1 === u1.getFileNames().length);
+
+      let cursor = 0;
+      const blockSize = 1024;
+      const reader = async () => {
+        if (cursor >= dbytes.byteLength) return undefined;
+        const next = dbytes.subarray(
+          cursor,
+          Math.min(cursor + blockSize, dbytes.byteLength),
+        );
+        cursor += blockSize;
+        return next;
+      };
+      nWrote = await u1.importDb(dbName2, reader);
+      T.assert(2 === u1.getFileCount());
+      db2 = new u1.OpfsSAHPoolDb(dbName2);
+      T.assert(db2 instanceof sqlite3.oo1.DB).assert(
+        3 === db2.selectValue("select count(*) from t"),
+      );
+      db2.close();
+      T.assert(true === u1.unlink(dbName2)).assert(
+        dbytes.byteLength === nWrote,
+      );
+
+      T.assert(true === u1.unlink(dbName))
+        .assert(false === u1.unlink(dbName))
+        .assert(0 === u1.getFileCount())
+        .assert(0 === u1.getFileNames().length);
+
+      const conf2 = JSON.parse(JSON.stringify(sahPoolConfig));
+      conf2.name += "-test2";
+      const POther = await inst(conf2);
+      T.assert(0 === POther.getFileCount()).assert(
+        true === (await POther.removeVfs()),
+      );
+
+      T.assert(true === (await u2.removeVfs()))
+        .assert(false === (await u1.removeVfs()))
+        .assert(!sqlite3.capi.sqlite3_vfs_find(sahPoolConfig.name));
+
+      let cErr;
+      let u3;
+      conf2.$testThrowPhase2 = new Error("Testing throwing during init.");
+      conf2.name = `${sahPoolConfig.name}-err`;
+      const P3 = await inst(conf2)
+        .then((u) => (u3 = u))
+        .catch((e) => (cErr = e));
+      T.assert(P3 === conf2.$testThrowPhase2)
+        .assert(cErr === P3)
+        .assert(u3 === undefined)
+        .assert(!sqlite3.capi.sqlite3_vfs_find(conf2.name));
+      delete conf2.$testThrowPhase2;
+      T.assert(
+        cErr === (await inst(conf2).catch((e) => e)),
+        "Init result is cached even if it failed",
+      );
+
+      cErr = undefined;
+      u3 = undefined;
+      conf2.forceReinitIfPreviouslyFailed = true;
+      conf2.verbosity = 3;
+      const P3b = await inst(conf2)
+        .then((u) => (u3 = u))
+        .catch((e) => (cErr = e));
+      T.assert(cErr === undefined)
+        .assert(P3b === u3)
+        .assert(P3b === (await inst(conf2)))
+        .assert(true === (await u3.removeVfs()))
+        .assert(false === (await P3b.removeVfs()));
+    },
+  });
+}

--- a/tests/opfs-API-tests/js/test-harness.js
+++ b/tests/opfs-API-tests/js/test-harness.js
@@ -1,0 +1,162 @@
+const roundMs = (ms) => Math.round(ms * 100) / 100;
+
+export function createTestHarness({ logClass, error, reportFinalTestStatus }) {
+  const TestUtil = {
+    counter: 0,
+    toBool(expr) {
+      return expr instanceof Function ? !!expr() : !!expr;
+    },
+    assert(expr, ...msg) {
+      ++this.counter;
+      if (!this.toBool(expr)) {
+        throw new Error(msg.length ? msg.join(" ") : "Assertion failed.");
+      }
+      return this;
+    },
+    mustThrowMatching(fn, filter, msg) {
+      ++this.counter;
+      let err;
+      try {
+        fn();
+      } catch (e) {
+        err = e;
+      }
+      if (!err) throw new Error(msg || "Expected exception.");
+      let pass = false;
+      if (filter instanceof RegExp) pass = filter.test(err.message);
+      else if (filter instanceof Function) pass = filter(err);
+      else if (typeof filter === "string") pass = err.message === filter;
+      if (!pass) {
+        throw new Error(msg || `Filter rejected this exception: ${err.message}`);
+      }
+      return this;
+    },
+    TestGroup: (() => {
+      let groupCounter = 0;
+      class TestGroup {
+        constructor(name, predicate) {
+          this.number = ++groupCounter;
+          this.name = name;
+          this.predicate = predicate;
+          this.tests = [];
+        }
+        addTest(testObj) {
+          this.tests.push(testObj);
+          return this;
+        }
+        async run(sqlite3) {
+          logClass("group-start", `Group #${this.number}:`, this.name);
+          if (this.predicate) {
+            const predicateResult = this.predicate(sqlite3);
+            if (!predicateResult || typeof predicateResult === "string") {
+              logClass(
+                ["warning", "skipping-group"],
+                "SKIPPING group:",
+                predicateResult || "predicate says to",
+              );
+              return;
+            }
+          }
+          const assertBaseline = TestUtil.counter;
+          const groupState = Object.create(null);
+          let runtime = 0;
+          let index = 0;
+          for (const test of this.tests) {
+            ++index;
+            const label = `${this.number}.${index}`;
+            logClass("one-test-line", `${label}:`, test.name);
+            if (test.predicate) {
+              const predicateResult = test.predicate(sqlite3);
+              if (!predicateResult || typeof predicateResult === "string") {
+                logClass(
+                  ["warning", "skipping-test"],
+                  "SKIPPING:",
+                  predicateResult || "predicate says to",
+                );
+                continue;
+              }
+            }
+            const startCount = TestUtil.counter;
+            const started = performance.now();
+            await test.test.call(groupState, sqlite3);
+            const ended = performance.now();
+            runtime += ended - started;
+            logClass(
+              ["faded", "one-test-summary"],
+              TestUtil.counter - startCount,
+              "assertion(s) in",
+              roundMs(ended - started),
+              "ms",
+            );
+          }
+          logClass(
+            ["green", "group-end"],
+            `#${this.number}:`,
+            TestUtil.counter - assertBaseline,
+            "assertion(s) in",
+            roundMs(runtime),
+            "ms",
+          );
+        }
+      }
+      return TestGroup;
+    })(),
+    testGroups: [],
+    currentTestGroup: undefined,
+    addGroup(name, predicate) {
+      this.testGroups.push(
+        (this.currentTestGroup = new this.TestGroup(name, predicate)),
+      );
+      return this;
+    },
+    addTest(test) {
+      if (arguments.length === 1) {
+        this.currentTestGroup.addTest(test);
+      } else {
+        const [name, callback] = arguments;
+        this.currentTestGroup.addTest({
+          name,
+          predicate: undefined,
+          test: callback,
+        });
+      }
+      return this;
+    },
+    async runTests(sqlite3) {
+      try {
+        let runtime = 0;
+        for (const group of this.testGroups) {
+          const started = performance.now();
+          await group.run(sqlite3);
+          runtime += performance.now() - started;
+        }
+        logClass(
+          ["strong", "green", "full-test-summary"],
+          "Done running tests.",
+          TestUtil.counter,
+          "assertions in",
+          roundMs(runtime),
+          "ms",
+        );
+        reportFinalTestStatus(true);
+      } catch (e) {
+        error(e);
+        reportFinalTestStatus(false);
+        throw e;
+      }
+    },
+  };
+
+  const harness = {
+    TestUtil,
+    T: TestUtil,
+    addGroup: TestUtil.addGroup.bind(TestUtil),
+    addTest: TestUtil.addTest.bind(TestUtil),
+    runTests: TestUtil.runTests.bind(TestUtil),
+  };
+
+  TestUtil.g = harness.addGroup;
+  TestUtil.t = harness.addTest;
+
+  return harness;
+}

--- a/tests/opfs-API-tests/js/ui.js
+++ b/tests/opfs-API-tests/js/ui.js
@@ -1,0 +1,86 @@
+const mapToString = (value) => {
+  switch (typeof value) {
+    case "number":
+    case "string":
+    case "boolean":
+    case "undefined":
+    case "bigint":
+      return String(value);
+  }
+  if (value === null) return "null";
+  if (value instanceof Error) {
+    return JSON.stringify(
+      {
+        message: value.message,
+        stack: value.stack,
+        errorClass: value.name,
+      },
+      undefined,
+      2,
+    );
+  }
+  try {
+    return JSON.stringify(value, undefined, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const normalizeArgs = (args) => args.map(mapToString);
+
+export function initUi() {
+  const logTarget = document.querySelector("#test-output");
+  const checkboxReverse = document.querySelector("#cb-log-reverse");
+  const titleElement = document.querySelector("title");
+  const header = document.querySelector("#color-target");
+  const originalTitle = titleElement?.textContent ?? "";
+
+  if (header && originalTitle) {
+    header.textContent = originalTitle;
+  }
+
+  const logClass = (cssClass, ...args) => {
+    const entry = document.createElement("div");
+    entry.classList.add("log-entry");
+    const classList = Array.isArray(cssClass) ? cssClass : [cssClass];
+    classList.filter(Boolean).forEach((cls) => entry.classList.add(cls));
+    entry.append(document.createTextNode(normalizeArgs(args).join(" ")));
+    logTarget.append(entry);
+  };
+
+  const updateLogOrder = () => {
+    logTarget.classList[checkboxReverse.checked ? "add" : "remove"](
+      "reverse",
+    );
+  };
+
+  checkboxReverse.addEventListener("change", updateLogOrder, true);
+  updateLogOrder();
+
+  const reportFinalTestStatus = (pass) => {
+    if (header) {
+      header.classList.add(pass ? "tests-pass" : "tests-fail");
+    }
+    if (titleElement) {
+      titleElement.textContent = `${pass ? "PASS" : "FAIL"}: ${originalTitle}`;
+    }
+  };
+
+  const log = (...args) => logClass(undefined, ...args);
+  const warn = (...args) => {
+    console.warn(...args);
+    logClass("warning", ...args);
+  };
+  const error = (...args) => {
+    console.error(...args);
+    logClass("error", ...args);
+  };
+
+  return {
+    log,
+    warn,
+    error,
+    logClass,
+    reportFinalTestStatus,
+  };
+}


### PR DESCRIPTION
## Summary
- rework the OPFS API test runner markup with a lightweight header, controls, and log container
- replace the shared testing stylesheet with a tailored theme focused on a clean, legible layout
- tag each log entry with consistent styling while preserving warning/error emphasis

## Testing
- pnpm run test:opfs-api

------
https://chatgpt.com/codex/tasks/task_e_68d6647596008325a95317c1f627123a